### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ data/docs/
 
 ## Architecture
 
-The system is based on the well-known LAMP stack (Linux, Apache 2+, MySQL 5+, PHP 5.4+) and the popular and powerful
+The system is based on the well-known LAMP stack (Linux, Apache 2+, MySQL 5+, PHP 5.6+) and the popular and powerful
 [Zend Framework 2](http://framework.zend.com/) (2.5).
 
 It is compatible with PHP version up to and including 7.2 - bot not PHP 7.3+. We are currently working on an upgrade of the underlying Zend Framework to make it compatible with PHP 7.3+.


### PR DESCRIPTION
I just Upgraded PHP to 5.5 and got an error that PHP doesn't understand "use function xyz" in /vendor/zendframework/zend-diactoros/src/functions/marshal_headers_from_sapi.php on line 10. This construct was introduced with PHP 5.6 so I change the reqs here in the readme. Maybe the version_compare in setup.php should be risen too.