### PR TITLE
Fix "There is no active transaction" error on saving prices

### DIFF
--- a/module/Square/src/Square/Manager/SquarePricingManager.php
+++ b/module/Square/src/Square/Manager/SquarePricingManager.php
@@ -60,7 +60,7 @@ class SquarePricingManager extends AbstractManager
 
         try {
             $adapter = $this->squarePricingTable->getAdapter();
-            $adapter->query('TRUNCATE TABLE ' . SquarePricingTable::NAME, Adapter::QUERY_MODE_EXECUTE);
+            $adapter->query('DELETE FROM ' . SquarePricingTable::NAME, Adapter::QUERY_MODE_EXECUTE);
 
             $statement = $adapter->query('INSERT INTO ' . SquarePricingTable::NAME . ' (sid, priority, date_start, date_end, day_start, day_end, time_start, time_end, price, rate, gross, per_time_block) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
             );
@@ -71,10 +71,11 @@ class SquarePricingManager extends AbstractManager
                 }
 
                 $statement->execute($rule);
-                $transaction = false;
             }
 
-            $connection->commit();
+            if ($transaction) {
+				$connection->commit();
+			}
 
             $this->getEventManager()->trigger('create', $rules);
 
@@ -509,3 +510,4 @@ class SquarePricingManager extends AbstractManager
     }
 
 }
+


### PR DESCRIPTION
A defective transaction handling caused an "There is no active transaction" PDO error while still everything was saved.

Changed `TRUNCATE` to transaction safe `DELETE FROM` and only call `commit` when in a transaction.

Fixes #613 